### PR TITLE
Added DEFAULT_AUTO_FIELD in 'project/settings.py' to prevent warnings

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -2,6 +2,10 @@ from configurations import values
 
 from djangitos.settings import BaseConfig
 
+# Temporary solution to make sure Django picks up the default auto_field.
+# Model checks are performed before django-configurations are instantiated
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
 
 class ProjectConfig(BaseConfig):
     SOCIALACCOUNT_GOOGLE_CLIENT_ID = values.Value()


### PR DESCRIPTION
**Description:**

This PR addresses the warnings issued by django regarding DEFAULT_AUTO_FIELD when starting the development server:

<details>
  <summary>python manage.py runserver 0.0.0.0:8060</summary>

```
django-configurations version 2.3.1, using configuration ProjectConfig
Watching for file changes with StatReloader
Watching for file changes with StatReloader
Performing system checks...

System check identified some issues:

WARNINGS:
account.EmailAddress: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the AccountConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
account.EmailConfirmation: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the AccountConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
post_office.Attachment: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the PostOfficeConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
post_office.Email: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the PostOfficeConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
post_office.EmailTemplate: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the PostOfficeConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
post_office.Log: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the PostOfficeConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
ses_sns.BlacklistedEmail: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the SesSnsConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
ses_sns.SNSNotification: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the SesSnsConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
socialaccount.SocialAccount: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the SocialAccountConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
socialaccount.SocialApp: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the SocialAccountConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
socialaccount.SocialToken: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the SocialAccountConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.

System check identified 11 issues (0 silenced).
```
</details>

Most likely it's because the model checking [_check_default_pk(cls):](https://github.com/django/django/blob/8d9827c06ce1592cca111e7eafb9ebe0153104ef/django/db/models/base.py#L1322) gets called before the django-configurations config class gets instantiated.

The temporary solution in this PR is adding `DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'` in `project/settings.py` outside the config class so that it gets picked up by django's model checks.

<details>
  <summary>python manage.py runserver 0.0.0.0:8060</summary>

```
docker container logs djangitos-web-1                                                                           ✔ 
django-configurations version 2.3.1, using configuration ProjectConfig
Watching for file changes with StatReloader
Watching for file changes with StatReloader
Performing system checks...

System check identified no issues (0 silenced).

You have 40 unapplied migration(s). Your project may not work properly until you apply the migrations for app(s): account, admin, auth, contenttypes, post_office, redirects, ses_sns, sessions, sites, socialaccount, usermodel.
Run 'python manage.py migrate' to apply them.
November 13, 2021 - 17:08:01
Django version 3.2.9, using settings 'project.settings'
Starting development server at http://0.0.0.0:8060/
Quit the server with CONTROL-C.

```
</details>


